### PR TITLE
Derive the version from the git tag instead of a checked-in file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          # `pip install -e .` resolves the version from the git tag via
+          # hatch-vcs; a shallow clone has no tag, so the installed package
+          # would report `0.1.devN` instead of the release line.
+          fetch-depth: 0
 
       - name: Conda setup
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,9 +8,14 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        # hatch-vcs derives the version from the git tag, which a shallow clone
+        # does not have. Without this the build silently produces a
+        # `0.0.0.dev...` artifact instead of the release version.
+        fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -19,6 +24,19 @@ jobs:
         pip install build twine
     - name: Build package
       run: python -m build
+    # Deriving the version from the tag should make this unfalsifiable, but it
+    # is the last point at which a mismatch is cheap to see: the alternative
+    # symptom is a 400 from PyPI at the very end of the release, and only when
+    # that version already exists.
+    - name: Built version must match the release tag
+      run: |
+        built=$(ls dist/*.tar.gz | sed -E 's|.*/xwmb-(.*)\.tar\.gz|\1|')
+        tag="${GITHUB_REF_NAME#v}"
+        echo "tag=$tag built=$built"
+        if [ "$built" != "$tag" ]; then
+          echo "::error::Release tag $GITHUB_REF_NAME implies version '$tag', but the build produced '$built'."
+          exit 1
+        fi
     - name: Publish package
       env:
         TWINE_USERNAME: __token__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .ipynb_checkpoints
 __pycache__
 /paper/data/*.nc
+
+# Version file generated from the git tag by hatch-vcs at build time.
+xwmb/_version.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,15 @@ build:
   os: ubuntu-24.04
   tools:
     python: "miniforge3-latest"
+  jobs:
+    post_checkout:
+      # RTD clones shallow, but installing xwmb resolves its version from the
+      # git tag via hatch-vcs, and the docs are titled with it
+      # (`docs/source/conf.py` reads it from the installed metadata). Without
+      # the tag they would say `.devN`. Tolerate failure: an already-complete
+      # clone makes `--unshallow` an error, which must not fail the build.
+      - git fetch --unshallow || true
+      - git fetch --tags || true
 
 sphinx:
   builder: html

--- a/README.md
+++ b/README.md
@@ -47,3 +47,38 @@ python -m ipykernel install --user --name docs_env_xwmb --display-name "docs_env
 jupyter-lab
 ```
 
+Releasing
+---------
+
+**The git tag is the version.** `xwmb` has no version string checked into the
+source tree: `hatch-vcs` derives it from the tag at build time and writes
+`xwmb/_version.py` (gitignored, but shipped inside the sdist and wheel). To cut a
+release you tag; there is no file to bump and nothing to keep in sync.
+
+1. Make sure `main` is green and has everything you want in the release.
+2. **Publish a GitHub Release** whose tag is `vX.Y.Z`, targeting the commit you
+   want to ship:
+   ```bash
+   gh release create vX.Y.Z --target "$(git rev-parse origin/main)" \
+     --title vX.Y.Z --generate-notes
+   ```
+   Publishing it (not merely pushing a tag) is what fires the workflow. Target
+   the commit you actually want: a tag placed *before* the commit you meant to
+   release builds the previous version, and PyPI rejects it as a duplicate.
+3. The **Publish to PyPI** workflow builds from that tag and uploads. It checks
+   out with `fetch-depth: 0` so the tag is visible to `hatch-vcs`, and asserts
+   that the built version matches the tag before publishing.
+4. Verify: <https://pypi.org/project/xwmb/>.
+5. conda-forge builds from the PyPI sdist and lags by design; the autotick bot
+   opens the version-bump PR. The feedstock recipe must list `hatch-vcs`
+   alongside `hatchling` in its `host` requirements, since it builds with
+   `--no-build-isolation`.
+
+Two things follow from the tag being the version. Never add a version literal
+back to the tree — `xwmb/version.py` is a shim over the generated file, and a
+`0.0.0+unknown` from it means the package was imported without being built or
+installed, not that a number is missing. And any checkout that installs the
+package needs its tags: a shallow clone, or a fork that never fetched them,
+resolves a `.devN` version instead of the release line. That is why CI checks out
+with `fetch-depth: 0` and Read the Docs unshallows in `post_checkout`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,25 @@ dependencies = [
 "Bugs/Issues/Features" = "https://github.com/hdrake/xwmb/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+# The version comes from the git tag, not from a file in the tree. Releasing is
+# then a single act -- tag `vX.Y.Z` and publish the GitHub Release -- with no
+# second commit to remember, and no way for the tag and the built artifact to
+# disagree about which version they are.
 [tool.hatch.version]
-path = "xwmb/version.py"
+source = "vcs"
+
+# Drop the `+g<sha>` local segment. On a clean tag the version is exactly X.Y.Z
+# either way, but an untagged build would otherwise carry a PEP 440 *local*
+# version, which package indexes refuse outright. Untagged builds are
+# `X.Y.Z.devN` instead, which an index will accept.
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
+# Building writes the resolved version to `xwmb/_version.py`, which is gitignored
+# but *is* included in the sdist -- so `pip install` from the sdist, and
+# conda-forge's build from the PyPI sdist, both work without git present.
+[tool.hatch.build.hooks.vcs]
+version-file = "xwmb/_version.py"

--- a/xwmb/version.py
+++ b/xwmb/version.py
@@ -1,3 +1,18 @@
-"""xwmb: version information"""
+"""xwmb: version information.
 
-__version__ = "0.6.0"
+The version is derived from the git tag at build time by ``hatch-vcs``, which
+writes the resolved value to ``xwmb/_version.py``. That file is generated rather
+than checked in: there is deliberately no version string in the source tree that
+could drift out of step with the tag it is supposed to describe.
+
+``_version.py`` ships in every built artifact -- wheel, sdist, and editable
+install -- so the fallback below only fires when ``xwmb`` is imported straight
+from a source checkout that has never been built or installed.
+"""
+
+try:
+    from xwmb._version import __version__
+except ImportError:  # pragma: no cover - un-built source checkout
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Ports the scheme from [hdrake/xeos#10](https://github.com/hdrake/xeos/pull/10) to `xwmb`: the version is derived from the git tag by `hatch-vcs` instead of being read from a literal in `xwmb/version.py`.

## Why

`xwmb/version.py` held `__version__ = "0.6.0"`, which had to be bumped in its own commit before every release. Nothing tied that commit to the tag the release was actually cut from, so the two could disagree — and when they did, the symptom was a `400 File already exists` from PyPI at the very end of the release. That is exactly how the `xeos` v0.2.1 release failed: the tag was placed one commit before the bump, the workflow built the previous version, and PyPI rejected it.

With the tag as the source of truth, tagging **is** the bump. There is no second commit to remember and no way for the tag and the artifact to disagree.

## What changed

- **`pyproject.toml`** — `hatch-vcs` added to `build-system.requires`; `[tool.hatch.version]` switches from `path = "xwmb/version.py"` to `source = "vcs"`; `local_scheme = "no-local-version"` so untagged builds are `X.Y.Z.devN` rather than PEP 440 local versions that indexes refuse; a build hook writes the resolved version to `xwmb/_version.py`.
- **`xwmb/version.py`** — now a shim that imports from the generated `_version.py`, with a `0.0.0+unknown` fallback for a checkout that has never been built or installed. `xwmb.__version__` is unchanged for anything installed from a release.
- **`.gitignore`** — ignores the generated `xwmb/_version.py`.
- **`.github/workflows/publish-to-pypi.yml`** — `fetch-depth: 0` (a shallow clone has no tag, so the build would silently produce a `.devN` artifact), plus a step asserting the built version matches the release tag. `checkout`/`setup-python` bumped off the long-EOL v2.
- **`.github/workflows/ci.yml`** — `fetch-depth: 0` on the checkout, since the job installs the package.
- **`.readthedocs.yaml`** — `post_checkout` unshallows and fetches tags. `docs/source/conf.py` titles the pages with the installed version, so without this they would read `.devN`.
- **`README.md`** — a `Releasing` section documenting the tag-is-the-version procedure and the two invariants it implies.

## Verified locally

- Clean tag → exact version: building at a throwaway `v9.9.9` produces `xwmb-9.9.9.tar.gz` / `.whl`, no suffix, with the generated `xwmb/_version.py` inside the sdist.
- `main` is exactly at `v0.6.0`, so today's build there is `0.6.0` — identical to what the literal produced.

## Follow-up needed on the feedstock

conda-forge builds with `--no-build-isolation`, so the backend's requirements must be present in `host`. [conda-forge/xwmb-feedstock](https://github.com/conda-forge/xwmb-feedstock)'s recipe currently lists only `hatchling`; I confirmed locally that building the sdist that way with no `hatch-vcs` installed fails in `hatchling.builders.plugin.interface.get_build_hooks`. **`hatch-vcs` must be added next to `hatchling` in the feedstock's `host` requirements before the next release builds.**

## Note on untagged checkouts

A checkout without tags — a shallow clone, or a fork that never fetched them — now resolves a `.devN` version rather than the release line. That is why every checkout in CI uses `fetch-depth: 0`, and it is worth pushing the release tags to any fork you install from with `pip install git+https://…`.

## CI is red for an unrelated, pre-existing reason

The three `build` jobs fail at collection with
`ImportError: cannot import name 'flatten_lol' from 'xbudget'`, raised from the
**installed PyPI `xwmt` 0.2.0**: that release imports a helper `xbudget` removed in
0.7. It is a dependency-compatibility problem in the environment, not something this
branch touches — `main` has not run CI since February 2026 and would fail the same
way today. Nothing here changes Python outside `version.py`.

What this PR *is* responsible for did pass in those same runs: `pip install -e .`
resolved the version from the tag, and `conda list` reports `xwmb 0.6.1.dev2` (tag
`v0.6.0` plus the PR's merge commits). On `main` itself, which sits exactly on the
tag, the build is `0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
