### PR TITLE
Drop layer/interface from the sectionate call (unbreaks #43 against sectionate 0.4.0rc2)

### DIFF
--- a/xwmb/transport.py
+++ b/xwmb/transport.py
@@ -246,10 +246,13 @@ def _convergence_along_section(
     wmb, region, lambda_var, target_coords, utr, vtr, prebinned
 ):
     grid = wmb.grid
-    zc = grid.axes["Z"].coords["center"]
-    zi = grid.axes["Z"].coords["outer"]
     # sectionate needs a horizontal-only grid (a Z axis breaks its corner padding);
     # `_ds` is shared, so transports/tracers still resolve against the full dataset.
+    # It labels the transport vertically without being told how: the layer coordinate
+    # is a dimension of `utr`/`vtr` and comes along with them, whatever grid it is
+    # handed. (The matching interface coordinate would come from a vertical axis, which
+    # `hgrid` deliberately does not have -- but it never survived this call site anyway,
+    # since it sits on its own dimension and is dropped by the extraction below.)
     hgrid = horizontal_grid(grid)
 
     convs, tracers = [], []
@@ -261,8 +264,6 @@ def _convergence_along_section(
             f_c=loop.f_c,
             utr=utr,
             vtr=vtr,
-            layer=zc,
-            interface=zi,
             geometry="spherical",
             positive_in=region.mask,
         )


### PR DESCRIPTION
Downstream half of hdrake/sectionate#7, which is now **merged and released as sectionate 0.4.0rc2** (PyPI, 2026-08-04). Stacked on #43 (`modernize-for-v0.7.0`), where this call site lives, and targeted at it.

**This is not a forward-looking change any more — it repairs #43 against the sectionate its own `pyproject.toml` resolves to.** `sectionate >= 0.4.0rc1` picks up 0.4.0rc2, which no longer has `layer`/`interface` parameters at all, so `_convergence_along_section` raises `TypeError: convergent_transport() got an unexpected keyword argument 'layer'`. #43's last green CI run (2026-08-02) installed 0.4.0rc1, published two days before rc2; re-run today it fails.

### What changed upstream

`convergent_transport` dropped both arguments because neither was carrying information the call did not already have:

- the **layer** coordinate is a dimension of the transports themselves, so it reaches the output whether or not anyone names it;
- the **interface** coordinate cannot ride along (it is one point longer), but the grid names it: whichever axis registers the transports' layer dimension at its `"center"` position.

That axis is `grid.axes["Z"]` — precisely where this function read the two names from before handing them straight back:

```python
zc = grid.axes["Z"].coords["center"]
zi = grid.axes["Z"].coords["outer"]
...
    layer=zc,
    interface=zi,
```

So the whole change is deleting them. Five lines, one function.

### Why this is a no-op beyond unbreaking the call

- **The layer coordinate arrives either way** — it is a dimension of the `utr`/`vtr` this call passes, independent of which grid sectionate is handed.
- **The interface coordinate never survived this call site.** Two independent reasons, either alone sufficient: this call passes `hgrid = horizontal_grid(grid)`, which has no vertical axis for sectionate to read one off; and even on a grid that does, the interface coordinate sits on its own dimension, so `.rename(...)["conv_mass_transport"]` drops it (extracting a DataArray keeps only coordinates whose dims are a subset of its own). The `interface=` name was the only thing putting it on the returned Dataset, and nothing ever read it from there.
- **Nothing downstream wants it.** `transform_to_lambda` takes both its target and its `target_data` from `grid._ds`.

### Verification

Checked, not argued — #43 brings a test suite that covers this path, so this is testable in a way it was not on `main`:

- **57 passed, 0 skipped, 0 failed** locally against sectionate's merged head, whose `transports.py` is byte-identical to the released 0.4.0rc2 wheel (verified by `diff`). That includes the three tests that run against the real CM4p25 file, and `test_tiled_boundary_transport_obeys_divergence_theorem` / `test_fold_transport_methods_agree`, which check the along-section transport numerically rather than just calling it.
- **Reverting just this hunk against that same sectionate fails 4 tests** with the `TypeError` above — so the tests genuinely exercise this call, and this is the hunk that fixes it.
- CI on this PR is green (3.11/3.12/3.13 + docs), installing sectionate 0.4.0rc2 from PyPI.
- On the sectionate side the equivalence is pinned directly: on a grid with a vertical axis, `convergent_transport(grid, i_c, j_c)` returns output `xr.testing.assert_identical` to the same call passing `layer=grid.axes["Z"].coords["center"], interface=grid.axes["Z"].coords["outer"]`.

**Not done:** the two example notebooks were not re-executed. `ECCO_AABW_watermass_budget.ipynb` is the one that touches this path (`along_section=True`), and its data is a 2.7 GB / 12-file Zenodo record I did not pull; `MOM6_water_mass_budgets.ipynb` does not use `along_section` at all. Worth a run of the ECCO notebook before merging, though the suite already covers the multi-tile along-section path.

### Note

There is an `update-sectionate-API` branch (`1e23195 Updated sectionate API after breaking v0.4.0 changes`) that predates #43 and covers the pre-modernization layout. If it also addresses this, close whichever of the two is redundant.

<sub>Drafted with AI assistance (Claude Code). I have read the diff and run the tests myself.</sub>
